### PR TITLE
Added EmailEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The definition of developer-first for this repo is:
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [zigi](https://www.zigi.ai/) - Developer’s assistant for mundane non-coding tasks via Slack.
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.
+* [EmailEngine](https://emailengine.app/) - API and webhooks for existing email accounts
 
 ## Monitoring
 *Monitoring your production application.*

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The definition of developer-first for this repo is:
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [zigi](https://www.zigi.ai/) - Developer’s assistant for mundane non-coding tasks via Slack.
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.
-* [EmailEngine](https://emailengine.app/) - API and webhooks for existing email accounts
+* [EmailEngine](https://emailengine.app/) - API and webhooks for existing email accounts (IMAP & SMTP).
 
 ## Monitoring
 *Monitoring your production application.*


### PR DESCRIPTION
EmailEngine allows accessing email accounts using a REST API instead of IMAP