### PR TITLE
Adds Docraptor HTML to PDF API, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The definition of developer-first for this repo is:
 
 ## Reports Generation
 *Generating reports, mainly PDFs*
+* [DocRaptor[(https://docraptor.com) - HTML to PDF API built specifically for Paged Media using the Prince PDF library
 * [PDFBlade](https://pdfblade.com/#pricing) - HTML to PDF API usage based pricing.
 * [Carbone](https://carbone.io/) - JSON into PDF, DOCX, XLSX, PPTX, ODS... API.
 * [Export SDK](https://exportsdk.com) - PDF generator API with visual template editor.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The definition of developer-first for this repo is:
 * [PDFBlade](https://pdfblade.com/#pricing) - HTML to PDF API usage based pricing.
 * [Carbone](https://carbone.io/) - JSON into PDF, DOCX, XLSX, PPTX, ODS... API.
 * [Export SDK](https://exportsdk.com) - PDF generator API with visual template editor.
-* [DocRaptor[(https://docraptor.com) - HTML to PDF API built specifically for Paged Media using the Prince PDF library
+* [DocRaptor[(https://docraptor.com) - HTML to PDF API built specifically for Paged Media using the [Prince](https://www.princexml.com/) PDF library.
 
 ## Scraping
 *Fetching data from websites not via an intended API.*

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ The definition of developer-first for this repo is:
 
 ## Reports Generation
 *Generating reports, mainly PDFs*
-* [DocRaptor[(https://docraptor.com) - HTML to PDF API built specifically for Paged Media using the Prince PDF library
 * [PDFBlade](https://pdfblade.com/#pricing) - HTML to PDF API usage based pricing.
 * [Carbone](https://carbone.io/) - JSON into PDF, DOCX, XLSX, PPTX, ODS... API.
 * [Export SDK](https://exportsdk.com) - PDF generator API with visual template editor.
+* [DocRaptor[(https://docraptor.com) - HTML to PDF API built specifically for Paged Media using the Prince PDF library
 
 ## Scraping
 *Fetching data from websites not via an intended API.*


### PR DESCRIPTION
Duplicate of now closed #30 

The contribution guide requested the "most awesome" services, but I wasn't sure how much detail to put in the listing description. The tl;dr is that DocRaptor is the only API that uses the [Prince](https://www.princexml.com/) library which lets us do waaaaay more advanced stuff than browser-based HTML to PDF generatosr. Lot of print-specific kinds of [details](https://docraptor.com/samples), such as CMYK support, TIFF images, different headers and footers throughout the document, float-to-the-top-of-the-page, etc, etc. And solely targeted at developers with lots of code samples and agent libraries.

Apologies for opening a second PR. I expected the previous one to update when I updated the fork, but it did not.