### PR TITLE
Adding Interval.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The definition of developer-first for this repo is:
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [zigi](https://www.zigi.ai/) - Developer’s assistant for mundane non-coding tasks via Slack.
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.
+* [Interval](https://interval.com/) - SDK to build internal tools and scripts for your product.
 
 ## Monitoring
 *Monitoring your production application.*


### PR DESCRIPTION
Interval ([https://interval.com]) is an API that allows developers to build internal apps in your backend codebase with zero frontend code.
It can save a lot of work for developers who want to offer non-technical teammates tools for managing accounts, moderating content, etc.

* I have no relationship with Interval. I just saw the tool and thought it worth sharing.