### PR TITLE
Move Volta to OUTCAST.md

### DIFF
--- a/OUTCAST.md
+++ b/OUTCAST.md
@@ -14,6 +14,9 @@ These are entries that were almost up for being in the main readme but I've deci
 ## Computer Vision
 * [Scanbot SDK](https://scanbot.io/) - Structured data extraction from images for applications. [Not developer-first enough]
 
+## Misc
+* [Volta](https://volta.net) - Fast, elegant GitHub desktop and web app. [Acquired]
+
 ## Monitoring
 * [Dashbird](https://dashbird.io/) - Serverless realtime monitoring. [Not developer-first enough]
 * [LogDNA](https://logdna.com/) - Log management and alerts. [Not developer-first enough]

--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [SignatureAPI](https://signatureapi.com) - API-first electronic signatures.
 * [Tempo](https://tempolabs.ai/) - Code-first Figma alternative. [![LW24 participant](https://img.shields.io/badge/featured-LW24-8957E5.svg?style=flat-square&labelColor=0D1117&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev/lw/2024/mega#participants)
 * [Trophy](https://trophy.so) - APIs for gamified product experiences.
-* [Volta](https://volta.net) - Fast, elegant GitHub desktop and web app.
 
 ## Monitoring
 *Monitoring your production application.*


### PR DESCRIPTION
NuxtLabs announced they're joining Vercel a few days ago.

As part of this transition, they took the decision to sunset Volta on December 31, 2025. It will no longer be available starting January 1st, 2026.