### PR TITLE
Add en-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 *Track web/app visitors.*
 * [Baremetrics](https://baremetrics.com/) - Subscription analytics for Stripe.
 * [devActivity](https://devactivity.com/) - Contributions analytics with AI Insights, Performance Review, Retrospectives and Gamifications.
+* [en-git](https://en-git.vercel.app/) - Open-source analytics platform for GitHub profiles/repos, with embeddable widgets, AI insights, and a code-quality Chrome extension. [![en-git](https://img.shields.io/github/stars/TejasS1233/en-git?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/TejasS1233/en-git)
 * [Heap](https://heap.io/) - Product analytics API for web and mobile, captures all events. 
 * [Mixpanel](https://mixpanel.com/) - Product analytics and dashboards.
 * [Pirsch](https://pirsch.io/) - Privacy-friendly web analytics with a backend integration and API.


### PR DESCRIPTION
Added en-git as an open-source analytics platform for GitHub profiles and repositories.
https://en-git.vercel.app/

## checklist

Please make sure you've complied with the [contribution guidelines](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md):
- [x] The homepage clearly states that the product is for developers.
  > "Headless", "API-First", "SaaS" are frequently used keywords.
  > Usually this means that the front page has some code examples :)
- [ ] The product is available now and requires payment.
- [x] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [x] The new submission isn't a duplicate.
- [x] The entry has a description, is sorted alphabetically, and ends with a full stop.

Note to maintainer: I've left the "requires payment" box unchecked. en-git is a "developer-first product" and is fully open-source (similar to other projects on the list like Plausible/PostHog), but it does not currently have a paid/SaaS tier. I believe it's a valuable tool for the developer community and fits the spirit of the list.

Thanks!
Thanks!
