### PR TITLE
Add ScraperCity to Scraping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [Corsfix](https://corsfix.com) - CORS Proxy to fetch any web resource and bypass CORS errors.
 * [Crawlbase](https://proxycrawl.com/) - Scrape hard-to-scrape websites with proxies.
 * [Proxy Sentinel](https://www.proxysentinel.io) - A self-managed proxy rotator.
+* [ScraperCity](https://scrapercity.com) - Web scraping API with specialized pre-built scrapers for Apollo.io, Google Maps, and YouTube. Built-in proxy rotation, JavaScript rendering, and CAPTCHA handling.
 * [ScrapingANT](https://scrapingant.com/) - Scrape with headless chrome.
 * [ScrapingBee](https://www.scrapingbee.com/) - Using headless browsers and proxies to scrape without being blocked.
 * [SearchApi](https://www.searchapi.io/) - Real-time Google SERP API.


### PR DESCRIPTION
Adding ScraperCity - a web scraping API focused on specialized, target-specific scrapers.

**Existing players in Scraping:**
- Apify (general platform, turn any website into an API)
- browserless (headless browser automation service)
- Corsfix (CORS proxy solution)
- Crawlbase (proxy-based scraping for hard-to-scrape sites)
- Proxy Sentinel (self-managed proxy rotator)

**Why ScraperCity:**
While existing tools focus on infrastructure (proxies, browsers, CORS) or general-purpose scraping platforms, ScraperCity provides specialized, ready-to-use APIs for specific high-value targets. Instead of building and maintaining scraping logic for Apollo.io, Google Maps, or YouTube, developers get production-ready APIs that handle target-specific challenges (authentication, rate limits, data parsing) out of the box. Reduces integration from days/weeks to minutes for these specific data sources.

Meets criteria:
✅ Developer-focused (code examples on front page)
✅ API-first SaaS product
✅ Paid service with clear pricing

https://scrapercity.com

## checklist

Please make sure you've complied with the [contribution guidelines](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md):
- [x] The homepage clearly states that the product is for developers.
  > "Headless", "API-First", "SaaS" are frequently used keywords.
  > Usually this means that the front page has some code examples :)
- [x] The product is available now and requires payment.
- [x] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [x] The new submission isn't a duplicate.
- [x] The entry has a description, is sorted alphabetically, and ends with a full stop.
- [ ] 
Thanks!
