### PR TITLE
Add DevDocsAI, AITranslateKit, and OGKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [ReadMe](https://readme.com/) - Personalized and dynamic developer docs.
 * [Speakeasy](https://speakeasy.com/) - API tooling for SDKs, API docs, Terraform providers, and end-to-end testing. [![LW24 participant](https://img.shields.io/badge/featured-LW24-8957E5.svg?style=flat-square&labelColor=0D1117&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev/lw/2024/mega#participants)
 * [Swimm](https://swimm.io/) - Docs that are coupled with your code, auto-synced, works with your IDE.
+* [DevDocsAI](https://devdocsai-sigma.vercel.app/) - AI-powered API documentation generator. Paste code, get docs in 30 seconds. [![DevDocsAI](https://img.shields.io/github/stars/snowman95/devdocsai?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/snowman95/devdocsai)
 
 ## Environment & Secret Management
 *Manage environment variables and secrets for multiple apps or projects.*
@@ -291,6 +292,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [Localazy](https://localazy.com/) - App translation built for developers.
 * [Locize](https://locize.com) - The translation management system created by the creators of i18next. Work with writers in dev/stage env before hitting prod.
 * [Tolgee](https://tolgee.io) - Developer & translator friendly web-based localization platform.
+* [AITranslateKit](https://aitranslatekit.vercel.app/) - AI-powered i18n JSON file translator. Preserves variables and nested structures across 20+ languages. [![AITranslateKit](https://img.shields.io/github/stars/snowman95/aitranslatekit?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/snowman95/aitranslatekit)
 
 ## Mail
 *Sending emails as a service.*
@@ -316,6 +318,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [ImageKit](https://imagekit.io/) - Automate image optimization, transformation, and delivery.
 * [imgix](https://www.imgix.com/) - Transforms, optimizes, and cache images.
 * [Mux](https://mux.com/) - APIs to upload, manage, and stream video. [![featured on launchweek.dev](https://img.shields.io/badge/featured-0D1117.svg?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev)
+* [OGKit](https://ogkit.vercel.app/) - Generate dynamic Open Graph images via URL parameters. 6 templates, 6 themes, no signup required. [![OGKit](https://img.shields.io/github/stars/snowman95/ogkit?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/snowman95/ogkit)
 * [Pintura](https://pqina.nl/pintura) - A fully configurable JavaScript image editor SDK.
 
 ## Messaging


### PR DESCRIPTION
Adding three developer-first tools:

**Documentation:**
- **DevDocsAI** — AI-powered API documentation generator. Paste your API code, get complete docs in 30 seconds. Supports REST, GraphQL, and gRPC.

**Localization:**
- **AITranslateKit** — AI-powered i18n JSON file translator. Preserves variables (`{name}`, `{{count}}`) and nested structures. Supports 20+ languages.

**Media:**
- **OGKit** — Generate dynamic Open Graph images via URL parameters. 6 templates, 6 themes, no signup required. Free API.

All three are open-source, developer-first tools with API/code-first interfaces.