### PR TITLE
Add ShotOG to Media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [imgix](https://www.imgix.com/) - Transforms, optimizes, and cache images.
 * [Mux](https://mux.com/) - APIs to upload, manage, and stream video. [![featured on launchweek.dev](https://img.shields.io/badge/featured-0D1117.svg?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev)
 * [Pintura](https://pqina.nl/pintura) - A fully configurable JavaScript image editor SDK.
+* [ShotOG](https://shotog.2214962083.workers.dev) - Open-source OG image generation API with templates, batch generation, and custom fonts. [![ShotOG](https://img.shields.io/github/stars/nicepkg/shotog?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/nicepkg/shotog)
 
 ## Messaging
 *Messaging APIs - SMS, notifications, chats, and VoIP.*


### PR DESCRIPTION
Added [ShotOG](https://shotog.2214962083.workers.dev) to the **Media** section.

ShotOG is an open-source OG image generation API. Developers can generate Open Graph images via a simple API with 8 built-in templates, batch generation, and custom fonts support.

- **GitHub:** https://github.com/nicepkg/shotog
- **License:** MIT (open-source core, COSS badge included)

ShotOG fits the Media category alongside APITemplate.io and similar image generation APIs, providing a self-hostable, developer-first alternative.