### PR TITLE
Add Revieko to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 * [Ellipsis](http://ellipsis.dev/) - AI code reviews and bug fixes. [![LW24 participant](https://img.shields.io/badge/featured-LW24-8957E5.svg?style=flat-square&labelColor=0D1117&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev/lw/2024/mega#participants)
 * [Kodus](https://kodus.io/) - Open-source code review agent. [![Kodus](https://img.shields.io/github/stars/kodustech/kodus-ai?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/kodustech/kodus-ai)
 * [Sonar](https://www.sonarsource.com/) - Lint and code quality checks.
+* [Revieko](https://synqra.tech/revieko) - Architecture drift radar for pull requests (structural risk scoring and drift hotspots).
 
 ## Computer Vision
 *Manipulate and detect visual data.*


### PR DESCRIPTION
Added Revieko as a new tool for architecture drift radar.

https://github.com/apps/revieko-architecture-drift-radar
https://synqra.tech/revieko

## checklist

Please make sure you've complied with the [contribution guidelines](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md):
- [ ] The homepage clearly states that the product is for developers.
  > "Headless", "API-First", "SaaS" are frequently used keywords.
  > Usually this means that the front page has some code examples :)
- [ ] The product is available now and requires payment.
- [ ] The product reached a significant milestone: 1K GH Stars, 1K followers, awarded on Product Hunt, and/or SOC-2 compliant.
- [ ] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [ ] The new submission isn't a duplicate.
- [ ] The entry has a description, is sorted alphabetically, and ends with a full stop.

Thanks!
