### PR TITLE
Add Spiderhash for webhook/API callback debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,3 +457,5 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 ## Contributing
 
 See here: [CONTRIBUTING.md](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md)
+
+- [Spiderhash](https://spiderhash.io) - Inspect, debug, and replay webhook/API callback traffic with payload history and endpoint diagnostics.


### PR DESCRIPTION
## Summary\n- add Spiderhash (https://spiderhash.io) as a developer-first webhook/API callback debugging tool\n- include concise description focused on inspection, replay, and diagnostics\n\n## Why\nSpiderhash helps developers debug and validate webhook integrations, which fits this list's developer-first API tooling focus.