### PR TITLE
Add Frostbyte to GEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 ## GEO
 *Location services.*
 * [AirPinpoint](https://airpinpoint.com/) - API for Apple AirTags tracking. [![LW24 participant](https://img.shields.io/badge/featured-LW24-8957E5.svg?style=flat-square&labelColor=0D1117&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev/lw/2024/mega#participants)
+* [Frostbyte](https://frostbyte-landing.vercel.app) - IP geolocation and developer utility APIs with a free tier.
 * [Mapbox](https://www.mapbox.com/) - Maps and locations products for devs.
 * [OpenCage](https://opencagedata.com/) - Forward and reverse geocoding API based on open data.
 * [PlaceKit](https://placekit.io/) - Locations search API.


### PR DESCRIPTION
## Add Frostbyte to GEO section

[Frostbyte](https://frostbyte-landing.vercel.app) is an API-first platform providing IP geolocation and developer utility APIs.

### Why it fits developer-first criteria

- **API-first**: Every feature is accessible via REST API with JSON responses. The landing page has curl examples front and center.
- **Free tier**: 200 credits included, no credit card required to get started.
- **No signup for basic endpoints**: The IP geolocation endpoint works without authentication for simple lookups.
- **Developer experience**: Comprehensive docs, single API key for 40+ endpoints, standard REST conventions.

### Why GEO section

Frostbyte's core offering is IP geolocation — given an IP address, it returns country, city, coordinates, timezone, ISP, and threat intelligence data. This fits alongside OpenCage (geocoding), SmartyStreets (address verification), and Radar (geo APIs) in the GEO section.

### Competitors in this space

Compared to other GEO entries:
- **OpenCage** focuses on forward/reverse geocoding from addresses. Frostbyte focuses on IP-based geolocation.
- **SmartyStreets** specializes in US address verification. Frostbyte is global and IP-based.
- **Radar** is geofencing-focused. Frostbyte provides IP intelligence (location, ISP, threat data).

Frostbyte fills a gap in the list — none of the current GEO entries offer IP geolocation specifically, which is a common developer need for analytics, fraud detection, and content localization.