### PR TITLE
Add Changelog.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 *Documentation solutions.*
 * [Apidog](https://apidog.com/) - All-in-one API documentation tool, 1-click to generate API documentation from requests.
 * [Bump.sh](https://bump.sh/) - API documentation and change management solution.
+* [Changelog.dev](https://www.changelogdev.com) - Hosted changelog pages with AI-generated entries from git commits.
 * [DeveloperHub](https://developerhub.io/) - Collaborative developer documentation platform.
 * [Fern](https://www.buildwithfern.com/) - Instant docs and SDKs for APIs.
 * [Mintlify](https://www.mintlify.com/) - NextJS-based, AI-powered platform for documentation sites. [![featured on launchweek.dev](https://img.shields.io/badge/featured-0D1117.svg?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev)


### PR DESCRIPTION
## Summary

Adding [Changelog.dev](https://www.changelogdev.com) to the **Documentation** section.

Changelog.dev provides hosted changelog pages with AI-generated entries from git commits. Developers connect their GitHub repo, and the tool automatically generates human-readable changelog entries from commit history. It offers a free tier and is built specifically for developer teams who want to keep users informed without the manual overhead of writing release notes.

- Developers are the target audience
- SaaS / API-first product
- Free tier available

Sorted alphabetically (between Bump.sh and DeveloperHub).