### PR TITLE
Add daily.dev to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 ## Misc
 *Different products that probably don't have a category.*
 * [Actyx](https://www.actyx.com/) - Developer-first factory building.
+* [daily.dev](https://daily.dev/) - Personalized developer news feed aggregating from 1000+ tech sources with community discussion. [![daily.dev](https://img.shields.io/github/stars/dailydotdev/daily?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/dailydotdev/daily)
 * [Docusign](https://developers.docusign.com/) - APIs for eSignature, and Intelligent Agreement Management.
 * [Interval](https://interval.com/) - SDK to build internal tools and scripts for your product.
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).


### PR DESCRIPTION
## What is daily.dev?

[daily.dev](https://daily.dev/) is a personalized developer news feed that aggregates content from 1,000+ tech sources, with built-in community discussion features. It's used by 1M+ developers to stay up-to-date.

### Why it fits this list

- **Developer-first:** Built exclusively for developers — personalized feed based on interests, languages, and frameworks
- **Open-source:** 19K+ GitHub stars ([dailydotdev/daily](https://github.com/dailydotdev/daily))
- **Product:** Free tier + paid Plus plan with API access
- **Significant milestones:** 1M+ registered developers, featured on Product Hunt (multiple times), browser extension with 300K+ users

### Placement

Added to **Misc** as there isn't a dedicated "Developer News" or "Content Discovery" category. Happy to move it if you think another section fits better.

Sorted alphabetically (after Actyx, before Docusign).