### PR TITLE
Add ActivitySmith to Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 ## Messaging
 *Messaging APIs - SMS, notifications, chats, and VoIP.*
 * [Ably](https://ably.com) - Pub/sub, real-time messaging, notifications, chat, multiplayer and data synchronization.
+* [ActivitySmith](https://activitysmith.com/) - API-first iOS Live Activities and push notifications for backend events, deployments, jobs, and agent workflows.
 * [Applozic](https://www.applozic.com/) - Chat SDKs, real-time messaging.
 * [Knock](https://knock.app) - Notifications as a service. [![featured on launchweek.dev](https://img.shields.io/badge/featured-0D1117.svg?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev)
 * [MagicBell](https://www.magicbell.com/) - Real-time notification system with API & UI components.


### PR DESCRIPTION
I'm the founder of ActivitySmith.

I'm proposing ActivitySmith for the `Messaging` category.

Why it fits:
- developer-first, API-first product
- official SDKs and CLI for backend-triggered notifications
- focused on iOS Live Activities and push notifications for deployments, incidents, long-running jobs, and agent workflows

Relevant competitors already in this category include Knock, MagicBell, Novu, and Twilio.

Why ActivitySmith stands out from that group:
- more operational / developer-workflow oriented than user-notification infrastructure
- supports iOS Live Activities, not just one-off notifications
- built for backend events, CI, scripts, automations, and agent runs rather than only customer messaging use cases

Happy to adjust the wording or move categories if you think another section is a better fit.