### PR TITLE
Add Fluranto to developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [Propexo](https://www.propexo.com/) - Unified API to integrate with property management systems.
 * [SignatureAPI](https://signatureapi.com) - API-first electronic signatures.
 * [Trophy](https://trophy.so) - APIs for gamified product experiences.
+* [Fluranto](https://www.fluranto.com/en/developer) - Browser-first developer tools for JSON, Base64, JWT, regex, URLs, and format conversion. No signup required; sensitive payloads stay in the browser.
 
 ## Monitoring
 *Monitoring your production application.*


### PR DESCRIPTION
Added Fluranto as a new resource for developer tools.

[Insert URL to the product here.]

## checklist

Please make sure you've complied with the [contribution guidelines](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md):
- [ ] The homepage clearly states that the product is for developers.
  > "Headless", "API-First", "SaaS" are frequently used keywords.
  > Usually this means that the front page has some code examples :)
- [ ] The product is available now and requires payment.
- [ ] The product reached a significant milestone: 1K GH Stars, 1K followers, awarded on Product Hunt, and/or SOC-2 compliant.
- [ ] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [ ] The new submission isn't a duplicate.
- [ ] The entry has a description, is sorted alphabetically, and ends with a full stop.

Thanks!
