### PR TITLE
Add Onepilot to AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 * [JetBrains AI](https://www.jetbrains.com/ai) - JetBrains’s AI offering integrated into most of their IDEs.
 * [Kilo Code](https://kilocode.ai) - Fast, open-source AI coding agent for VS Code and JetBrains. [![Kilo Code](https://img.shields.io/github/stars/Kilo-Org/kilocode?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/Kilo-Org/kilocode)
 * [Mastra](https://mastra.ai) - Build AI agents with a modern TypeScript stack. [![Mastra](https://img.shields.io/github/stars/mastra-ai/mastra?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/mastra-ai/mastra)
+* [Onepilot](https://onepilotapp.com/) - Mobile app to SSH into servers and run AI coding agents (Claude Code, Codex) from your phone.
 * [OpenHands](https://all-hands.dev/) - an open-source Devin alternative. [![OpenHands](https://img.shields.io/github/stars/All-Hands-AI/OpenHands?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/All-Hands-AI/OpenHands)
 * [Qodo](https://www.qodo.ai/) - Focusing on confident code generation (focused on testing well).
 * [Replit AI](http://repl.it/) - Replit’s code IDE using AI (has also a free limited plan).


### PR DESCRIPTION
## What is Onepilot?

[Onepilot](https://onepilotapp.com/) is an iOS app that lets developers SSH into remote servers and run AI coding agents (Claude Code, Codex, etc.) directly from their phone. It bridges the gap between mobile and the terminal-based AI coding tools that currently require a desktop.

## Why it belongs here

- **Developer-first**: Built specifically for developers who want to monitor, launch, or interact with AI coding agents on the go.
- **Fits the AI Coding category**: Complements existing desktop-focused entries (Cursor, Warp, Aider) by covering the mobile use case.
- **Available on the App Store**: Shipped product with active users.

## Competitors in this category

Most AI coding tools in the list are desktop IDE extensions or terminal tools. Onepilot is the only mobile-native option for running AI coding agents via SSH, so it fills a gap rather than duplicating an existing entry.

## Checklist

- [x] Entry is alphabetically sorted
- [x] Follows the format
- [x] Link verified, not a duplicate
- [x] One resource per PR