### PR TITLE
Add Helium

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [Actyx](https://www.actyx.com/) - Developer-first factory building.
 * [daily.dev](https://daily.dev/) - Personalized developer news feed aggregating from 1000+ tech sources with community discussion. [![daily.dev](https://img.shields.io/github/stars/dailydotdev/daily?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/dailydotdev/daily)
 * [Docusign](https://developers.docusign.com/) - APIs for eSignature, and Intelligent Agreement Management.
+* [Helium](https://heliumtrades.com/mcp-page/) - Real-time news intelligence with bias scoring via MCP or REST, live financial market data and AI options pricing, and one-line MCP integration for coding assistants; free tier (50 queries, no signup).
 * [Interval](https://interval.com/) - SDK to build internal tools and scripts for your product.
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.


### PR DESCRIPTION
https://heliumtrades.com/mcp-page/

Adds Helium under **Misc** (alphabetically after Docusign). Misc already includes developer news products such as [daily.dev](https://daily.dev/); Helium is complementary as an API-first layer for real-time news intelligence (including bias scoring), market data, and MCP integration for coding assistants rather than a consumer feed UI.

## checklist

Please make sure you've complied with the [contribution guidelines](https://github.com/agamm/awesome-developer-first/blob/main/CONTRIBUTING.md):
- [x] The homepage clearly states that the product is for developers.
  > "Headless", "API-First", "SaaS" are frequently used keywords.
  > Usually this means that the front page has some code examples :)
- [x] The product is available now and requires payment.
- [ ] The product reached a significant milestone: 1K GH Stars, 1K followers, awarded on Product Hunt, and/or SOC-2 compliant.
- [x] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [x] The new submission isn't a duplicate.
- [x] The entry has a description, is sorted alphabetically, and ends with a full stop.

Thanks!