### PR TITLE
added Shiplog to the documentation section (shiplog.page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 ## Documentation
 *Documentation solutions.*
 * [Apidog](https://apidog.com/) - All-in-one API documentation tool, 1-click to generate API documentation from requests.
+* [Shiplog](https://shiplog.page) - Polished changelog onto your own public page (yourapp.shiplog.page). Publish entries via UI dashboard or CLI.
 * [Bump.sh](https://bump.sh/) - API documentation and change management solution.
 * [DeveloperHub](https://developerhub.io/) - Collaborative developer documentation platform.
 * [Fern](https://www.buildwithfern.com/) - Instant docs and SDKs for APIs.


### PR DESCRIPTION
I proposed to add a tool called Shiplog (https://shiplog.page) that allows creators and developers to organise and host their product's updates on their own polished changelog public page (yourapp.shiplog.page). They can add entries via UI Dashboard, AI (by entering rough notes) or CLI directly from the project's terminal. The entire setup takes less than 60 seconds. Free 7-day trial, then 4.99$/mo. Example page: https://calcifyai.shiplog.page