### PR TITLE
Add varg AI video SDK to Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [imgix](https://www.imgix.com/) - Transforms, optimizes, and cache images.
 * [Mux](https://mux.com/) - APIs to upload, manage, and stream video. [![featured on launchweek.dev](https://img.shields.io/badge/featured-0D1117.svg?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzYwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDM2MCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+IDxyZWN0IHdpZHRoPSI2MCIgaGVpZ2h0PSIzMDAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjYwIiB5PSIzMDAiIHdpZHRoPSIxMjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjI0MCIgeT0iMzAwIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IndoaXRlIi8+IDxyZWN0IHg9IjMwMCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjMwMCIgZmlsbD0id2hpdGUiLz4gPHJlY3QgeD0iMTgwIiB3aWR0aD0iNjAiIGhlaWdodD0iMzAwIiBmaWxsPSJ3aGl0ZSIvPiA8L3N2Zz4=)](https://launchweek.dev)
 * [Pintura](https://pqina.nl/pintura) - A fully configurable JavaScript image editor SDK.
+* [varg](https://github.com/vargHQ/sdk) - Open-source SDK for AI video generation. JSX components, 40+ models (Kling, Sora, Flux, ElevenLabs) behind one API key.
 
 ## Messaging
 *Messaging APIs - SMS, notifications, chats, and VoIP.*


### PR DESCRIPTION
Adding varg, an open-source SDK for AI video generation, to the Media section. Sits alongside Mux, Cloudinary, ImageKit as developer-first media infra.

Repo: https://github.com/vargHQ/sdk
License: Apache-2.0