### PR TITLE
Add Frigade

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [Actyx](https://www.actyx.com/) - Developer-first factory building.
 * [daily.dev](https://daily.dev/) - Personalized developer news feed aggregating from 1000+ tech sources with community discussion. [![daily.dev](https://img.shields.io/github/stars/dailydotdev/daily?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/dailydotdev/daily)
 * [Docusign](https://developers.docusign.com/) - APIs for eSignature, and Intelligent Agreement Management.
+* [Frigade](https://frigade.com) - SDK for shipping an in-product AI assistant that learns your app and takes actions on the user's behalf (open modals, navigate, walk through workflows).
 * [Interval](https://interval.com/) - SDK to build internal tools and scripts for your product.
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.


### PR DESCRIPTION
Adds Frigade — SDK for shipping an in-product AI assistant that learns your app and takes actions on the user's behalf. Inserted alphabetically between Docusign and Interval in Misc, since the existing entries (Plain, Trophy, Interval) cover similar developer-shipped product-experience APIs/SDKs.