### PR TITLE
Add Commitment Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 * [Security](#security)
 * [Shipping](#shipping)
 * [Testing](#testing)
+- [Commitment Issues](https://github.com/dotsystemsdevs/commitmentissues) - Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.
  
 ---
 


### PR DESCRIPTION
Adding **Commitment Issues** to agamm/awesome-developer-first.

### What it does
Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.

### Why it fits
- Free, open source (MIT), no signup, no ads
- Useful for developers vetting dependencies or cleaning up bookmarks
- Live at https://commitmentissues.dev, source at https://github.com/dotsystemsdevs/commitmentissues

Thanks for maintaining this list 🦥