### PR TITLE
Add RedirHub to Misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [ngrok](https://ngrok.com/) - Generate public URLs for internal servers (behind NAT/firewall).
 * [Nylas](https://www.nylas.com/) - APIs for productivity workflows (email, calendar, contacts...) - like plaid for productivity.
 * [Plain](https://plain.com) - API-first customer service platform (support, feedback, rating widgets...).
+* [RedirHub](https://redirhub.com) - API-first URL redirect infrastructure at the edge, with custom nameservers, edge network, and proactive link monitoring for developers.
 * [Propexo](https://www.propexo.com/) - Unified API to integrate with property management systems.
 * [SignatureAPI](https://signatureapi.com) - API-first electronic signatures.
 * [Trophy](https://trophy.so) - APIs for gamified product experiences.


### PR DESCRIPTION
### What this PR does
Adds RedirHub to the Misc section. RedirHub is an API-first URL redirect platform targeting developers — it has code examples on its homepage, a REST API, an MCP server for AI agents, custom nameservers, and an edge network with 20+ global nodes.

### Why RedirHub fits this list
- API-first infrastructure (dedicated API + MCP protocol for AI agents)
- Developer target audience (code examples on landing page)
- SaaS product with paid plans (not self-hosted/OSS)
- SOC 2 Type II compliant
- Product Hunt launch (community-vetted)

### Competitors in this space
- redirect.pizza — simpler, fewer features
- redirection.io — enterprise-focused, less developer-centric
- urllo — newer entrant
RedirHub is the most developer-complete offering in the redirect space with API, edge network, custom nameservers, and proactive monitoring.