### PR TITLE
Add BuilderStudio as a developer-first AI coding tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 
 ## Code Quality
 *Check your code quality.*
+
+* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
+
+
 * [Codacy](https://www.codacy.com/) - Automatic code quality checks.
 * [CodeRabbit AI](https://coderabbit.ai/) - AI-powered code review and automated pull request management.
 * [DebuggAI](https://debugg.ai) - Zero-config AI browser (E2E) tests that review every commit & pull request (PR).

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 * [Tabby](https://www.tabbyml.com/) - Self-hosted open-source coding assistant. [![tabby](https://img.shields.io/github/stars/TabbyML/tabby?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/TabbyML/tabby)
 * [Tabnine](https://www.tabnine.com/) - One of the OG players in the AI code assistant space.
 * [Warp](https://www.warp.dev/warp-ai) - Fully integrated AI in your terminal.
+* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
 
 ## Analytics
 *Track web/app visitors.*
@@ -155,10 +156,6 @@ For the latest additions [click here](https://github.com/agamm/awesome-developer
 
 ## Code Quality
 *Check your code quality.*
-
-* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
-
-
 * [Codacy](https://www.codacy.com/) - Automatic code quality checks.
 * [CodeRabbit AI](https://coderabbit.ai/) - AI-powered code review and automated pull request management.
 * [DebuggAI](https://debugg.ai) - Zero-config AI browser (E2E) tests that review every commit & pull request (PR).


### PR DESCRIPTION
## checklist

- [x] The homepage clearly states that the product is for developers.
- [x] The product is available now and requires payment.
- [ ] The product reached a significant milestone: 1K GH Stars, 1K followers, awarded on Product Hunt, and/or SOC-2 compliant.
- [x] The PR has a descriptive title -- e.g., `Add {Product}`, not `Update README.md`.
- [x] The new submission isn't a duplicate.
- [x] The entry has a description, is sorted alphabetically, and ends with a full stop.
- [x] This PR is a Markdown/list-entry-only BuilderStudio submission.
- [x] The entry uses public links for BuilderStudio and BuilderStudio Skills.

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp
