### PR TITLE
Add Geonode to Scraping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [browserless](https://browserless.io) - Browser automation deployed to the cloud. [![browserless](https://img.shields.io/github/stars/browserless/browserless?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/browserless/browserless)
 * [Corsfix](https://corsfix.com) - CORS Proxy to fetch any web resource and bypass CORS errors.
 * [Crawlbase](https://proxycrawl.com/) - Scrape hard-to-scrape websites with proxies.
+* [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
 * [Proxy Sentinel](https://www.proxysentinel.io) - A self-managed proxy rotator.
 * [ScrapingANT](https://scrapingant.com/) - Scrape with headless chrome.
 * [ScrapingBee](https://www.scrapingbee.com/) - Using headless browsers and proxies to scrape without being blocked.

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ web apps (including frontend). [![Reflex](https://img.shields.io/github/stars/re
 * [browserless](https://browserless.io) - Browser automation deployed to the cloud. [![browserless](https://img.shields.io/github/stars/browserless/browserless?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/browserless/browserless)
 * [Corsfix](https://corsfix.com) - CORS Proxy to fetch any web resource and bypass CORS errors.
 * [Crawlbase](https://proxycrawl.com/) - Scrape hard-to-scrape websites with proxies.
-* [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
+* [Geonode](https://geonode.com) - Rotating residential and datacenter proxies with REST API access.
 * [Proxy Sentinel](https://www.proxysentinel.io) - A self-managed proxy rotator.
 * [ScrapingANT](https://scrapingant.com/) - Scrape with headless chrome.
 * [ScrapingBee](https://www.scrapingbee.com/) - Using headless browsers and proxies to scrape without being blocked.


### PR DESCRIPTION
I run Geonode. Adding us to the **Scraping** list. Geonode does residential + datacenter proxies, fits next to scrapingbee.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential and datacenter proxies with REST API access.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.